### PR TITLE
Emit files using webpack instead of write files directly

### DIFF
--- a/lib/Plugin.js
+++ b/lib/Plugin.js
@@ -6,7 +6,6 @@ var async = require('async');
 var mkdirp = require('mkdirp');
 var _ = require('lodash');
 var path = require('path');
-var fs = require('fs');
 
 var processOptions = require('./processOptions');
 
@@ -18,6 +17,14 @@ function fThrow(x) { throw x; }
 
 SpritesmithPlugin.prototype = {
     apply: function (compiler) {
+        this.assets = {};
+        compiler.plugin('emit', function(compilation, cb) {
+            Object.keys(this.assets).forEach(function(asset) {
+                compilation.assets[asset] = this.assets[asset];
+            }.bind(this));
+            cb();
+        }.bind(this));
+
         compiler.plugin('run', function (compiler, callback) {
             return this.compile(callback);
         }.bind(this));
@@ -42,6 +49,7 @@ SpritesmithPlugin.prototype = {
         }.bind(this));
     },
     compile: function (compileCallback) {
+        var assets = {};
         async.waterfall([
             glob.bind(null, this.options.src.glob, {cwd: this.options.src.cwd}),
             function (fileNames, callback) {
@@ -95,13 +103,16 @@ SpritesmithPlugin.prototype = {
             spritesheet: spritesheet
         };
     },
-    writeImage: function (spritesmithResult, callback) {
-        fs.writeFile(
-            this.options.target.image,
-            spritesmithResult.image,
-            'binary',
-            callback
-        );
+    writeImage: function (assets, spritesmithResult, callback) {
+        assets[this.options.target.image] = {
+            size: function() {
+                return Buffer.byteLength(spritesmithResult.image);
+            },
+            source: function() {
+                return new Buffer(spritesmithResult.image, 'binary');
+            }
+        };
+        callback();
     }
 };
 

--- a/lib/Plugin.js
+++ b/lib/Plugin.js
@@ -74,11 +74,15 @@ SpritesmithPlugin.prototype = {
     writeCSS: function (spritesmithResult, callback) {
         var templaterData = this.convertSpritesmithResultToSpritesheetTemplatesFormat(spritesmithResult);
         var code = spritesheetTemplater(templaterData, this.options.spritesheetTemplatesOptions);
-        fs.writeFile(
-            this.options.target.css,
-            code,
-            callback
-        );
+        assets[this.options.target.css] = {
+            size: function() {
+                return code.length;
+            },
+            source: function() {
+                return code;
+            }
+        };
+        callback();
     },
     convertSpritesmithResultToSpritesheetTemplatesFormat: function (spritesmithResult) {
         var generateSpriteName = this.options.apiOptions.generateSpriteName || function (fileName) {


### PR DESCRIPTION
I had trouble because the plugin wasn't writing to the dist directly when I thought it was doing so
This actually updates it to use the webpack asset management stuff.

I figured out the proper solution is to change target.image and target.css to include the dist path, but i think this makes it a bit more straight forward and works with webpack dev server