### PR TITLE
fix(Plugin): add missing binding to sprite cleanup function

### DIFF
--- a/lib/Plugin.js
+++ b/lib/Plugin.js
@@ -84,7 +84,7 @@ SpritesmithPlugin.prototype = {
                     this.prevCompiledFilePaths = compiledFilesPaths;
                     callback();
                 }
-            }
+            }.bind(this)
         ], compileCallback);
     }
 };


### PR DESCRIPTION
When using multiple instances of the plugin, each instance will delete sprite created by the previous one.

This is due to a missing "this" binding for the cleanup callback. Without the binding, the "this" is the the same one for each iteration.