### PR TITLE
add source_image info for templates

### DIFF
--- a/lib/compileNormal.js
+++ b/lib/compileNormal.js
@@ -47,9 +47,11 @@ module.exports = function (options, metaOutput, isInitial, srcFiles, callback) {
         var sprites = _.map(
             spritesmithResult.coordinates,
             function (oneSourceInfo, fileName) {
-                return _.assign(
-                    {name: generateSpriteName(fileName)},
-                    oneSourceInfo
+                return _.assign({
+                    name: generateSpriteName(fileName),
+                    source_image: fileName
+                  },
+                  oneSourceInfo
                 );
             }
         );


### PR DESCRIPTION
Add source_image (path to original sprite file) for compability with gulp.spritesmith