### PR TITLE
add apiOptions.spritesheet_info;

### DIFF
--- a/src/compileNormal.js
+++ b/src/compileNormal.js
@@ -42,8 +42,8 @@ module.exports = async (options, metaOutput, isInitial, srcFiles) => {
 
         const spritesheet_info = options.apiOptions.spritesheet_info || {
             name:'spritesheet'
-        }
+        };
 
-        return {sprites, spritesheet ,spritesheet_info};
+        return {sprites, spritesheet, spritesheet_info};
     }
 };

--- a/src/compileNormal.js
+++ b/src/compileNormal.js
@@ -40,6 +40,10 @@ module.exports = async (options, metaOutput, isInitial, srcFiles) => {
             ...spritesmithResult.properties
         };
 
-        return {sprites, spritesheet};
+        const spritesheet_info = options.apiOptions.spritesheet_info || {
+            name:'spritesheet'
+        }
+
+        return {sprites, spritesheet ,spritesheet_info};
     }
 };


### PR DESCRIPTION
sometimes one file need to import more CSS pre-processor data;
to avoid variable name conflicts, should use api.spritesheet_info;

 - spritesheet_info `Object` - Optional container for metadata about `spritesheet` and its representation
        - name `String` - Prefix to use for all spritesheet variables
            - For example, `icons` will generate `$icons-width`/`$icons-image`/etc in a SCSS template
            - By default, this is `spritesheet` (e.g. `$spritesheet-width`, `$spritesheet-image`)